### PR TITLE
Fixed captions. issue42 done.

### DIFF
--- a/src/mediaelementplayer.min.css
+++ b/src/mediaelementplayer.min.css
@@ -733,9 +733,11 @@ a:visited {
 }
 
 .mejs-captions-text {
-	padding: 3px 5px;
+	/*padding: 3px 5px;*/
 	background: url(background.png);
 	background: rgba(20, 20, 20, 0.8);
+	white-space: pre-line;
+	line-height: normal;
 
 }
 /* End: TRACK (Captions and Chapters) */


### PR DESCRIPTION
HTML doesn't handle new line escape characters by default. However, this can be overcome using CSS. ~~Also changed the query function call from html() to text() as subtitle files are to be treated as text.~~ Oops, my bad. Reverted to html(). Padding on the caption-text create some weird offsets whilst displaying muti-line subtitles, so removed that.

Also could you update the git sub-modules? All of them are broken.