### PR TITLE
Basic support for .avi files

### DIFF
--- a/src/js/options.js
+++ b/src/js/options.js
@@ -11,7 +11,7 @@
         // features to show
         features: ['contextmenu', 'notification', 'playlist', 'source', 'playpause', 'stopButton', 'progress', 'current', 'duration', 'tracks', 'subdelay', 'subsize', 'volume', 'settings', 'info', 'help', 'fullscreen', 'drop', 'stats', 'opensubtitle', 'autosrt', 'shortcuts', 'thumbnail'],
         
-        mediaExts: ['aac', 'mp4', 'm4a', 'mp1', 'mp2', 'mp3', 'mpg', 'mpeg', 'oga', 'ogg', 'wav', 'webm', 'm4v', 'ogv', 'mkv'],
+        mediaExts: ['aac', 'avi', 'mp4', 'm4a', 'mp1', 'mp2', 'mp3', 'mpg', 'mpeg', 'oga', 'ogg', 'wav', 'webm', 'm4v', 'ogv', 'mkv'],
         
         subExts: ['srt', 'sub', 'txt', 'ass', 'dfxp', 'smi'],
         

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -14,7 +14,7 @@
     },
     "file_handlers": {
         "any": {
-            "extensions": ["aac", "mp4", "m4a", "mp1", "mp2", "mp3", "mpg", "mpeg", "oga", "ogg", "wav", "webm", "m4v", "ogv", "mkv"]
+            "extensions": ["aac", "avi", "mp4", "m4a", "mp1", "mp2", "mp3", "mpg", "mpeg", "oga", "ogg", "wav", "webm", "m4v", "ogv", "mkv"]
         }
     },
     "permissions":[


### PR DESCRIPTION
Support video files having .avi extension.

This is not changing the functionality of the player, just makes .avi -files visible in the open dialog
and application association.

The theory is, that this gives better user experience.
Given that more often than not, only thing needed to make the "avi" files working is to rename the
extension to something "supported", like .mp4, it is reasonable to assume that the inverse would work as well (i.e. don't refuse to open .avi files just because of their extension).