### PR TITLE
Track mouse events if there's such things.

### DIFF
--- a/src/js/mep-player.js
+++ b/src/js/mep-player.js
@@ -80,7 +80,7 @@
                     }
                 });
             }
-            else {
+            if('onmousemove' in window) {
                 // show/hide controls
                 t.container.on('mousemove', function() {
                         if(!t.controlsAreVisible) {


### PR DESCRIPTION
Prior to this patch, one doesn't get mouse events if there's touch functionality available.
This is a problematic choice for multiple reasons:

 - When seeking, the current code triggers a start of a ControlsTimer making controls to fade out.
 - There's something wrong with the touch screen part of the handling, making it such that touchstart events handler
   is not executed in Pixel2 (can't say for other devices) even though the handler is registered just fine and touchstart
   events are flowing somewhere according to the console.
This combination of issues leads into situation where when interacting with the controls it ends up fading away and staying away.

After this patch, one gets mouse events if system knows how to send them and move triggers showing of the controls.
This works as before for every non-touch-enabled devices, and significantly better for pixel2, whether it is used by touching or by mouse. Unclear how a pure touch-only device would behave though.